### PR TITLE
Fix background to support all browser

### DIFF
--- a/assets/components/quickstartbuttons/css/mgr23.css
+++ b/assets/components/quickstartbuttons/css/mgr23.css
@@ -69,8 +69,8 @@
 	border-radius:3px;
     box-shadow: 0 0 0 1px #e4e4e4;
     
-    background: -webkit-gradient(linear,left top,left bottom,color-stop(0%,#ffffff),color-stop(100%,#ededed));
-
+    background: transparent linear-gradient(to bottom,#ffffff,#ededed);
+    
     color: #555;
 	font: bold 11px tahoma, verdana, helvetica, sans-serif;
 	text-decoration: none;


### PR DESCRIPTION
Removed the vendor-prefix and definition for background gradient. It was only there for webkit, so FF did not show the button-background.
Other failsafe solution (not advisable): use all vendor-prefixes and definitions here.